### PR TITLE
fix: TailwindBuildProcess now properly unhooks SettingsChangedAsync

### DIFF
--- a/src/Build/TailwindBuildProcess.cs
+++ b/src/Build/TailwindBuildProcess.cs
@@ -74,7 +74,7 @@ namespace TailwindCSSIntellisense.Build
         {
             VS.Events.BuildEvents.ProjectBuildStarted -= StartProcess;
             VS.Events.DocumentEvents.Saved -= OnFileSave;
-            SettingsProvider.OnSettingsChanged -= SetFilePathsAsync;
+            SettingsProvider.OnSettingsChanged -= SettingsChangedAsync;
         }
 
         /// <summary>


### PR DESCRIPTION
Minor bug fix.

On L67, `SettingsChangedAsync` is added as an event listener.
On L77, `SetFilePathsAsync` was being removed as an event listener.