### PR TITLE
Added Cultureinfo on parse of spacing mapper.

### DIFF
--- a/src/Completions/CompletionUtilities.cs
+++ b/src/Completions/CompletionUtilities.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -127,7 +128,7 @@ namespace TailwindCSSIntellisense.Completions
                     }
                     else
                     {
-                        SpacingMapper[s] = $"{float.Parse(s) / 4}rem";
+                        SpacingMapper[s] = $"{float.Parse(s, CultureInfo.InvariantCulture) / 4}rem";
                     }
                 }
             }


### PR DESCRIPTION
This fixes intellisense when Windows number format has , instead of . in decimal numbers.