### PR TITLE
Add SortClassesOptions.Manual option

### DIFF
--- a/src/ClassSort/ClassSorter.cs
+++ b/src/ClassSort/ClassSorter.cs
@@ -124,7 +124,7 @@ internal sealed class ClassSorter : IDisposable
         {
             return;
         }
-        if (GetSettings().EnableTailwindCss && (GetSettings().SortClassesType != SortClassesOptions.None || GetSettings().SortClassesType != SortClassesOptions.Manual))
+        if (GetSettings().EnableTailwindCss && GetSettings().SortClassesType != SortClassesOptions.None)
         {
             string fileContent;
             Encoding encoding;

--- a/src/ClassSort/ClassSorter.cs
+++ b/src/ClassSort/ClassSorter.cs
@@ -124,7 +124,7 @@ internal sealed class ClassSorter : IDisposable
         {
             return;
         }
-        if (GetSettings().EnableTailwindCss && GetSettings().SortClassesType != SortClassesOptions.None)
+        if (GetSettings().EnableTailwindCss && (GetSettings().SortClassesType != SortClassesOptions.None || GetSettings().SortClassesType != SortClassesOptions.Manual))
         {
             string fileContent;
             Encoding encoding;

--- a/src/Commands/SortClassesInOpenFile.cs
+++ b/src/Commands/SortClassesInOpenFile.cs
@@ -35,7 +35,7 @@ namespace TailwindCSSIntellisense
             {
                 var file = await VS.Documents.GetActiveDocumentViewAsync();
 
-                if (string.IsNullOrWhiteSpace(file?.FilePath))
+                if (!string.IsNullOrWhiteSpace(file?.FilePath))
                 {
                     await ClassSorter.SortAsync(file.FilePath, true);
                 }

--- a/src/Commands/SortClassesInOpenFile.cs
+++ b/src/Commands/SortClassesInOpenFile.cs
@@ -1,5 +1,6 @@
 ﻿using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -34,10 +35,11 @@ namespace TailwindCSSIntellisense
             if (!ClassSorter.Sorting)
             {
                 var file = await VS.Documents.GetActiveDocumentViewAsync();
+                var path = file.TextBuffer.GetFileName();
 
-                if (!string.IsNullOrWhiteSpace(file?.FilePath))
+                if (!string.IsNullOrWhiteSpace(path))
                 {
-                    await ClassSorter.SortAsync(file.FilePath, true);
+                    await ClassSorter.SortAsync(path, true);
                 }
             }
         }

--- a/src/Options/General.cs
+++ b/src/Options/General.cs
@@ -52,7 +52,7 @@ namespace TailwindCSSIntellisense.Options
         public BuildProcessOptions BuildProcessType { get; set; } = BuildProcessOptions.Default;
         [Category("Class Sort")]
         [DisplayName("Class sort type")]
-        [Description("Classes can be sorted on file save (only sorts open file), on build (entire solution), or never.")]
+        [Description("Classes can be sorted manually (with 'Tools' options), on file save (only sorts open file), on build (entire solution), or never.")]
         [TypeConverter(typeof(EnumConverter))]
         [DefaultValue(SortClassesOptions.OnSave)]
         public SortClassesOptions ClassSortType { get; set; } = SortClassesOptions.OnSave;
@@ -79,6 +79,7 @@ namespace TailwindCSSIntellisense.Options
     {
         OnSave,
         OnBuild,
+        Manual,
         None
     }
 }


### PR DESCRIPTION
- Added the `SortClassesOptions.Manual` option to have the two class sorting actions (in Tools menu) without selecting onSave or onBuild.

Solve the issue #45 