### PR TITLE
Feature: File extensions listing OnSave

### DIFF
--- a/src/Build/TailwindBuildProcess.cs
+++ b/src/Build/TailwindBuildProcess.cs
@@ -143,12 +143,8 @@ namespace TailwindCSSIntellisense.Build
             }
 
             var extension = Path.GetExtension(filePath);
-            if (_settings.BuildType == BuildProcessOptions.OnSave &&
-                (extension == ".css" ||
-                extension == ".html" ||
-                extension == ".cshtml" ||
-                extension == ".razor" ||
-                extension == ".js"))
+            string[] extensions = new[] { ".css", ".html", ".cshtml", ".razor", ".js" };
+            if (_settings.BuildType == BuildProcessOptions.OnSave && extensions.Contains(extension))
             {
                 ThreadHelper.JoinableTaskFactory.Run(() => WriteToBuildPaneAsync("Tailwind CSS: Building..."));
                 StartProcess(_settings.AutomaticallyMinify);

--- a/src/Build/TailwindBuildProcess.cs
+++ b/src/Build/TailwindBuildProcess.cs
@@ -143,8 +143,7 @@ namespace TailwindCSSIntellisense.Build
             }
 
             var extension = Path.GetExtension(filePath);
-            string[] extensions = new[] { ".css", ".html", ".cshtml", ".razor", ".js" };
-            if (_settings.BuildType == BuildProcessOptions.OnSave && extensions.Contains(extension))
+            if (_settings.BuildType == BuildProcessOptions.OnSave && _settings.OnSaveTriggerFileExtensions.Contains(extension))
             {
                 ThreadHelper.JoinableTaskFactory.Run(() => WriteToBuildPaneAsync("Tailwind CSS: Building..."));
                 StartProcess(_settings.AutomaticallyMinify);

--- a/src/Options/General.cs
+++ b/src/Options/General.cs
@@ -41,6 +41,11 @@ namespace TailwindCSSIntellisense.Options
         [DefaultValue("{0}.output.css")]
         public string TailwindOutputFileName { get; set; } = "{0}.output.css";
         [Category("Build")]
+        [DisplayName("OnSave Trigger : File extensions")]
+        [Description("File extensions which will trigger the build at the onsave event.")]
+        [DefaultValue(".css;.html;.cshtml;.razor;.js")]
+        public string TailwindOnSaveTriggerFileExtensions { get; set; } = ".css;.html;.cshtml;.razor;.js";
+        [Category("Build")]
         [DisplayName("Tailwind CLI path")]
         [Description("The absolute path to the Tailwind CLI executable for building: if empty, the default npx tailwindcss build command will run; if not, the specified Tailwind CLI will be called")]
         public string TailwindCliPath { get; set; }

--- a/src/Settings/SettingsProvider.cs
+++ b/src/Settings/SettingsProvider.cs
@@ -68,6 +68,7 @@ namespace TailwindCSSIntellisense.Settings
                     {
                         EnableTailwindCss = general.UseTailwindCss,
                         DefaultOutputCssName = general.TailwindOutputFileName.Trim(),
+                        OnSaveTriggerFileExtensions = general.TailwindOnSaveTriggerFileExtensions.Split(';'),
                         BuildType = general.BuildProcessType,
                         BuildScript = general.BuildScript,
                         OverrideBuild = general.OverrideBuild,
@@ -126,6 +127,7 @@ namespace TailwindCSSIntellisense.Settings
                 {
                     EnableTailwindCss = general.UseTailwindCss,
                     DefaultOutputCssName = general.TailwindOutputFileName.Trim(),
+                    OnSaveTriggerFileExtensions = general.TailwindOnSaveTriggerFileExtensions.Split(';'),
                     BuildType = general.BuildProcessType,
                     BuildScript = general.BuildScript,
                     OverrideBuild = general.OverrideBuild,
@@ -254,7 +256,7 @@ namespace TailwindCSSIntellisense.Settings
                             Path.Combine(
                                 Path.GetDirectoryName(p.FullPath), "tailwind.config.js")
                             )
-                        )?.FullPath ?? 
+                        )?.FullPath ??
                     projects.First().FullPath);
             }
         }
@@ -272,6 +274,7 @@ namespace TailwindCSSIntellisense.Settings
 
             if (settings.UseTailwindCss != origSettings.EnableTailwindCss ||
                 settings.TailwindOutputFileName != origSettings.DefaultOutputCssName ||
+                !settings.TailwindOnSaveTriggerFileExtensions.Equals(origSettings.OnSaveTriggerFileExtensions) ||
                 settings.BuildProcessType != origSettings.BuildType ||
                 settings.BuildScript != origSettings.BuildScript ||
                 settings.OverrideBuild != origSettings.OverrideBuild ||
@@ -281,6 +284,7 @@ namespace TailwindCSSIntellisense.Settings
             {
                 origSettings.EnableTailwindCss = settings.UseTailwindCss;
                 origSettings.DefaultOutputCssName = settings.TailwindOutputFileName;
+                origSettings.OnSaveTriggerFileExtensions = settings.TailwindOnSaveTriggerFileExtensions.Split(';');
                 origSettings.BuildType = settings.BuildProcessType;
                 origSettings.BuildScript = settings.BuildScript;
                 origSettings.OverrideBuild = settings.OverrideBuild;

--- a/src/Settings/TailwindSettings.cs
+++ b/src/Settings/TailwindSettings.cs
@@ -6,6 +6,7 @@ namespace TailwindCSSIntellisense.Settings
     {
         public string TailwindConfigurationFile { get; set; }
         public string DefaultOutputCssName { get; set; }
+        public string[] OnSaveTriggerFileExtensions { get; set; }
         public string TailwindCssFile { get; set; }
         public string TailwindOutputCssFile { get; set; }
         public string PackageConfigurationFile { get; set; }


### PR DESCRIPTION
- Add a configuration field to choose which file extensions launch the CSS build on backup (if Build Type => OnSave is selected)
- Use a separator (e.g. the ; character) for each file extension to launch the event.

Resolve issue #60 