### PR TITLE
Set source directory to be directory of the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.13.12 (June 19th, 2026)
 
 - Set source directory to be directory of the configuration file even when `@import "tailwindcss"` is not present ([#147](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/147))
+- Properly configure `source()` and `config()` on alternative forms of Tailwind imports (i.e., `@import "tailwindcss/utilities" source(...);`)
 
 ## 1.13.11 (May 26th, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.13.12 (June 19th, 2026)
+
+- Set source directory to be directory of the configuration file even when `@import "tailwindcss"` is not present ([#147](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/147))
+
 ## 1.13.11 (May 26th, 2026)
 
 - Fix incorrect cmd format when building with the standalone CLI ([#146](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/146))

--- a/src/Completions/ProjectConfigurationManager.cs
+++ b/src/Completions/ProjectConfigurationManager.cs
@@ -21,7 +21,7 @@ namespace TailwindCSSIntellisense.Completions;
 /// </summary>
 [Export]
 [PartCreationPolicy(CreationPolicy.Shared)]
-public sealed class ProjectConfigurationManager
+public sealed class ProjectConfigurationManager : IDisposable
 {
     [Import]
     internal CompletionConfiguration Configuration { get; set; } = null!;
@@ -29,8 +29,6 @@ public sealed class ProjectConfigurationManager
     internal DirectoryVersionFinder DirectoryVersionFinder { get; set; } = null!;
     [Import]
     internal ProjectConfigurationInitializer ProjectConfigurationInitializer { get; set; } = null!;
-    [Import]
-    internal SettingsProvider SettingsProvider { get; set; } = null!;
 
     internal static ImageSource TailwindLogo { get; private set; } = new BitmapImage(new Uri(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Resources", "tailwindlogo.png"), UriKind.Relative));
 
@@ -52,11 +50,29 @@ public sealed class ProjectConfigurationManager
     /// </summary>
     private readonly SemaphoreSlim _configLock = new SemaphoreSlim(1, 1);
 
+    private bool hasSubscribedToConfigurationChangedEvent = false;
+
+    private void InitializeEventSubscriptions()
+    {
+        if (!hasSubscribedToConfigurationChangedEvent)
+        {
+            Configuration.ConfigurationUpdated += ConfigurationUpdatedAsync;
+            hasSubscribedToConfigurationChangedEvent = true;
+        }
+    }
+
+    private Task ConfigurationUpdatedAsync()
+    {
+        _filePathToProjectConfigurationCache.Clear();
+        return Task.CompletedTask;
+    }
+
     /// <summary>
     /// Returns the ProjectCompletionValues for the given configuration file path.
     /// </summary>
     public async Task<ProjectCompletionValues?> GetCompletionConfigurationByConfigFilePathAsync(string configFile)
     {
+        InitializeEventSubscriptions();
         await ProjectConfigurationInitializer.InitializeAsync();
 
         await _configLock.WaitAsync();
@@ -75,6 +91,7 @@ public sealed class ProjectConfigurationManager
     /// </summary>
     public async Task<ProjectCompletionValues> GetCompletionConfigurationByFilePathAsync(string? filePath)
     {
+        InitializeEventSubscriptions();
         await ProjectConfigurationInitializer.InitializeAsync();
 
         await _configLock.WaitAsync();
@@ -342,5 +359,13 @@ public sealed class ProjectConfigurationManager
         }
 
         await Configuration.ReloadCustomAttributesAsync(settings);
+    }
+
+    public void Dispose()
+    {
+        if (hasSubscribedToConfigurationChangedEvent)
+        {
+            Configuration.ConfigurationUpdated -= ConfigurationUpdatedAsync;
+        }
     }
 }

--- a/src/Completions/ProjectConfigurationManager.cs
+++ b/src/Completions/ProjectConfigurationManager.cs
@@ -49,22 +49,33 @@ public sealed class ProjectConfigurationManager : IDisposable
     /// SemaphoreSlim(1,1) is used instead of lock because the critical sections contain awaits.
     /// </summary>
     private readonly SemaphoreSlim _configLock = new SemaphoreSlim(1, 1);
+    private readonly object _subscriptionLock = new object();
 
-    private bool hasSubscribedToConfigurationChangedEvent = false;
+    private bool _hasSubscribedToConfigurationChangedEvent = false;
 
     private void InitializeEventSubscriptions()
     {
-        if (!hasSubscribedToConfigurationChangedEvent)
+        lock (_subscriptionLock)
         {
-            Configuration.ConfigurationUpdated += ConfigurationUpdatedAsync;
-            hasSubscribedToConfigurationChangedEvent = true;
+            if (!_hasSubscribedToConfigurationChangedEvent)
+            {
+                Configuration.ConfigurationUpdated += ConfigurationUpdatedAsync;
+                _hasSubscribedToConfigurationChangedEvent = true;
+            }
         }
     }
 
-    private Task ConfigurationUpdatedAsync()
+    private async Task ConfigurationUpdatedAsync()
     {
-        _filePathToProjectConfigurationCache.Clear();
-        return Task.CompletedTask;
+        await _configLock.WaitAsync();
+        try
+        {
+            _filePathToProjectConfigurationCache.Clear();
+        }
+        finally
+        {
+            _configLock.Release();
+        }
     }
 
     /// <summary>
@@ -363,9 +374,12 @@ public sealed class ProjectConfigurationManager : IDisposable
 
     public void Dispose()
     {
-        if (hasSubscribedToConfigurationChangedEvent)
+        lock (_subscriptionLock)
         {
-            Configuration.ConfigurationUpdated -= ConfigurationUpdatedAsync;
+            if (_hasSubscribedToConfigurationChangedEvent)
+            {
+                Configuration.ConfigurationUpdated -= ConfigurationUpdatedAsync;
+            }
         }
     }
 }

--- a/src/Configuration/ConfigFileParser.cs
+++ b/src/Configuration/ConfigFileParser.cs
@@ -224,7 +224,9 @@ internal static class ConfigFileParser
                         // Handle these cases:
                         // @import url("https://fonts.googleapis.com/css2?family=Roboto&display=swap");
                         // @import "some-plugin";
-                        if (import != "tailwindcss" && !directiveParameter.StartsWith("url"))
+                        // But not:
+                        // @import "tailwindcss/utilities";
+                        if (!import.Contains("tailwindcss") && !directiveParameter.StartsWith("url"))
                         {
                             var importPath = PathHelpers.GetAbsolutePath(Path.GetDirectoryName(path)!, import.EndsWith(".css") ? import : import + ".css");
 
@@ -241,9 +243,13 @@ internal static class ConfigFileParser
                             }
                         }
                         // Handle @import "tailwindcss" plus optional source(...) and prefix(...)
-                        else if (import == "tailwindcss")
+                        else if (import.Contains("tailwindcss"))
                         {
-                            if (directiveParameter.IndexOf("source(", secondQuote) is int index && index != -1)
+                            // source is applied on tailwindcss, tailwindcss/index, tailwindcss/utilities (which may
+                            // also be specified as ./node_modules/tailwindcss/utilities, etc.
+                            if ((import == "tailwindcss" || import.Contains("tailwindcss/index") ||
+                                import.Contains("tailwindcss/utilities")) &&
+                                directiveParameter.IndexOf("source(", secondQuote) is int index && index != -1)
                             {
                                 isSourceSpecified = true;
                                 if (directiveParameter.Substring(index + 7).Trim().StartsWith("none"))
@@ -265,7 +271,9 @@ internal static class ConfigFileParser
                                 content.Add(source);
                             }
 
-                            if (directiveParameter.IndexOf("prefix(", secondQuote) is int prefixIndex && prefixIndex != -1)
+                            // Either on the main import or theme
+                            if ((import == "tailwindcss" || import.Contains("tailwindcss/index") || import.Contains("tailwindcss/theme")) &&
+                                directiveParameter.IndexOf("prefix(", secondQuote) is int prefixIndex && prefixIndex != -1)
                             {
                                 var endParen = directiveParameter.IndexOf(')', prefixIndex);
 

--- a/src/Configuration/ConfigFileParser.cs
+++ b/src/Configuration/ConfigFileParser.cs
@@ -140,6 +140,8 @@ internal static class ConfigFileParser
 
         var prefix = "";
 
+        bool isSourceSpecified = false;
+
         for (int i = 0; i < fullText.Length; i++)
         {
             var current = fullText[i];
@@ -243,6 +245,7 @@ internal static class ConfigFileParser
                         {
                             if (directiveParameter.IndexOf("source(", secondQuote) is int index && index != -1)
                             {
+                                isSourceSpecified = true;
                                 if (directiveParameter.Substring(index + 7).Trim().StartsWith("none"))
                                 {
                                     continue;
@@ -260,11 +263,6 @@ internal static class ConfigFileParser
 
                                 source = PathHelpers.GetAbsolutePath(Path.GetDirectoryName(path)!, source)!;
                                 content.Add(source);
-                            }
-                            else
-                            {
-                                // If unset, the source path is the directory of the configuration file
-                                content.Add(Path.GetDirectoryName(path)!);
                             }
 
                             if (directiveParameter.IndexOf("prefix(", secondQuote) is int prefixIndex && prefixIndex != -1)
@@ -444,6 +442,12 @@ internal static class ConfigFileParser
                     variants[directiveParameter] += current.ToString();
                 }
             }
+        }
+
+        if (!isSourceSpecified)
+        {
+            // If no source(), the source path is the directory of the configuration file
+            content.Add(Path.GetDirectoryName(path)!);
         }
 
         var themeValuePairs = CssConfigSplitter.Split(themeTrimmed.ToString())

--- a/src/source.extension.cs
+++ b/src/source.extension.cs
@@ -12,7 +12,7 @@ namespace TailwindCSSIntellisense
         public const string Name = "Tailwind CSS for Visual Studio";
         public const string Description = @"Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.";
         public const string Language = "en-US";
-        public const string Version = "1.13.11";
+        public const string Version = "1.13.12";
         public const string Author = "Theron Wang";
         public const string Tags = "tailwind, tailwind css, css, html, cshtml, razor, blazor, intellisense, auto-completion";
         public const bool IsPreview = false;

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -16,12 +16,12 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 19.0)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 19.0)">
       <ProductArchitecture>arm64</ProductArchitecture>
     </InstallationTarget>
   </Installation>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" DisplayName="Visual Studio core editor" Version="[17.0,19.0)" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" DisplayName="Visual Studio core editor" Version="[17.0, 19.0)" />
   </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="TailwindCSSIntellisense.b29696d4-76a4-43d1-a203-c8e692368847" Version="1.13.11" Language="en-US" Publisher="Theron Wang" />
-        <DisplayName>Tailwind CSS for Visual Studio</DisplayName>
-        <Description xml:space="preserve">Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.</Description>
-        <MoreInfo>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio</MoreInfo>
-        <License>..\LICENSE</License>
-        <GettingStartedGuide>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/Getting-Started.md</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/CHANGELOG.md</ReleaseNotes>
-        <Icon>Resources\icon.png</Icon>
-        <PreviewImage>Resources\icon.png</PreviewImage>
-        <Tags>tailwind, tailwind css, css, html, cshtml, razor, blazor, intellisense, auto-completion</Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 19.0)">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-        <InstallationTarget Version="[17.0,19.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>arm64</ProductArchitecture>
-        </InstallationTarget>
-    </Installation>
-    <Dependencies>
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,19.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="TailwindCSSIntellisense.b29696d4-76a4-43d1-a203-c8e692368847" Version="1.13.12" Language="en-US" Publisher="Theron Wang" />
+    <DisplayName>Tailwind CSS for Visual Studio</DisplayName>
+    <Description xml:space="preserve">Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.</Description>
+    <MoreInfo>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio</MoreInfo>
+    <License>..\LICENSE</License>
+    <GettingStartedGuide>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/Getting-Started.md</GettingStartedGuide>
+    <ReleaseNotes>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/CHANGELOG.md</ReleaseNotes>
+    <Icon>Resources\icon.png</Icon>
+    <PreviewImage>Resources\icon.png</PreviewImage>
+    <Tags>tailwind, tailwind css, css, html, cshtml, razor, blazor, intellisense, auto-completion</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 19.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,19.0)">
+      <ProductArchitecture>arm64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" DisplayName="Visual Studio core editor" Version="[17.0,19.0)" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="|%CurrentProject%|" d:Source="Project" d:ProjectName="%CurrentProject%" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
#147 

@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Tailwind CSS `@import` parsing to correctly handle `source(...)`/`config()`-style imports and apply the configuration file directory to content when no source override is provided.
* **Bug Fixes**
  * Improved completion configuration update handling and ensured related event subscriptions are properly cleaned up.
* **Release**
  * Bumped the extension version to **1.13.12** and refreshed VSIX installation metadata for **amd64** and **arm64**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->