### PR TITLE
Ensure extension subprocess output/error encoding is UTF8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.14.1 (July 19th, 2026)
+
+- Prevent warnings from being recognized as errors in the Tailwind setup process
+- Prevent JSON parsing exceptions resulting from differences in locales ([#152](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/152))
+- Stop `@plugin` with block statements from breaking parsing of configuration files
+
 ## 1.14.0 (June 19th, 2026)
 
 - Fix a bug where only the last item added to the blocklist is counted

--- a/src/Configuration/ConfigFileParser.cs
+++ b/src/Configuration/ConfigFileParser.cs
@@ -52,6 +52,8 @@ internal static class ConfigFileParser
             Arguments =
                 $"/c node \"{scriptLocation}\" \"{Path.GetFileName(path)}\" {(isAPlugin ? "--plugin" : "")}",
             WorkingDirectory = Path.GetDirectoryName(path),
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
         };
 
         var localNodePath = await GetNodeModulesFromConfigFilePathAsync(path);
@@ -1067,6 +1069,7 @@ internal static class ConfigFileParser
             FileName = "cmd",
             Arguments = $"/c node -e \"console.log(require.resolve('{package}'))\"",
             WorkingDirectory = Path.GetDirectoryName(configFileLocation)!,
+            StandardOutputEncoding = Encoding.UTF8,
         };
 
         var localNodePath = await GetNodeModulesFromConfigFilePathAsync(configFileLocation);

--- a/src/Configuration/ConfigFileParser.cs
+++ b/src/Configuration/ConfigFileParser.cs
@@ -499,11 +499,7 @@ internal static class ConfigFileParser
                     // { is also a terminator for @plugin, so we'll handle that here
                     if (directive == "plugin")
                     {
-                        var plugin = directiveParameter
-                            .Replace("\"", "")
-                            .Replace("'", "")
-                            .TrimEnd(';')
-                            .Trim();
+                        var plugin = directiveParameter.Replace("\"", "").Replace("'", "").Trim();
 
                         var pluginAbsPath = PathHelpers.GetAbsolutePath(
                             Path.GetDirectoryName(path)!,
@@ -526,8 +522,6 @@ internal static class ConfigFileParser
                         {
                             imports.Add($"@plugin{pluginAbsPath}");
                         }
-
-                        continue;
                     }
 
                     directiveParameter = directiveParameter.Trim();

--- a/src/Helpers/DirectoryVersionFinder.cs
+++ b/src/Helpers/DirectoryVersionFinder.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Threading;
@@ -59,6 +60,7 @@ internal class DirectoryVersionFinder : IDisposable
             FileName = "cmd",
             Arguments = "/C npm list tailwindcss @tailwindcss/cli --depth=0",
             WorkingDirectory = directory,
+            StandardOutputEncoding = Encoding.UTF8,
         };
 
         string output;
@@ -81,6 +83,7 @@ internal class DirectoryVersionFinder : IDisposable
                 FileName = "cmd",
                 Arguments = "/C npm list tailwindcss @tailwindcss/cli --depth=0 -g",
                 WorkingDirectory = directory,
+                StandardOutputEncoding = Encoding.UTF8,
             };
 
             using var process = Process.Start(processInfo);
@@ -145,6 +148,7 @@ internal class DirectoryVersionFinder : IDisposable
                 ? $"/C \"{settings.TailwindCliPath}\" --help"
                 : "/C npm list tailwindcss --depth=0",
             WorkingDirectory = directory,
+            StandardOutputEncoding = Encoding.UTF8,
         };
 
         string output;
@@ -167,6 +171,7 @@ internal class DirectoryVersionFinder : IDisposable
                 FileName = "cmd",
                 Arguments = "/C npm list tailwindcss --depth=0 -g",
                 WorkingDirectory = directory,
+                StandardOutputEncoding = Encoding.UTF8,
             };
 
             using var process = Process.Start(processInfo);

--- a/src/Node/CheckForUpdates.cs
+++ b/src/Node/CheckForUpdates.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -88,6 +89,7 @@ internal static class CheckForUpdates
             FileName = "cmd",
             Arguments = $"/C npm outdated --json",
             WorkingDirectory = workingDir,
+            StandardOutputEncoding = Encoding.UTF8,
         };
 
         string output;
@@ -177,6 +179,7 @@ internal static class CheckForUpdates
             FileName = "cmd",
             Arguments = $"/C npm install {module}@{relevantPackage.Wanted}",
             WorkingDirectory = Path.GetDirectoryName(folder),
+            StandardErrorEncoding = Encoding.UTF8,
         };
 
         string error;

--- a/src/Node/CheckForUpdates.cs
+++ b/src/Node/CheckForUpdates.cs
@@ -183,15 +183,19 @@ internal static class CheckForUpdates
         };
 
         string error;
+        var failed = false;
 
         using (var process = Process.Start(processInfo))
         {
             error = await process.StandardError.ReadToEndAsync();
 
             await process.WaitForExitAsync();
+
+            failed = process.ExitCode != 0;
         }
 
-        if (!string.IsNullOrWhiteSpace(error))
+        // error may be non-empty but status code may still be 0 if the "error" is really a warning
+        if (!string.IsNullOrWhiteSpace(error) && failed)
         {
             var ex = new Exception(error);
             await ex.LogAsync();

--- a/src/Node/NpmHelpers.cs
+++ b/src/Node/NpmHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 
@@ -132,6 +133,8 @@ internal static class NpmHelpers
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
         };
     }
 }

--- a/src/Node/TailwindSetUpProcess.cs
+++ b/src/Node/TailwindSetUpProcess.cs
@@ -115,11 +115,15 @@ internal sealed class TailwindSetUpProcess
         ThreadHelper
             .JoinableTaskFactory.RunAsync(async () =>
             {
-                if (e.Data != null)
+                if (e.Data != null && !e.Data.Contains("warn"))
                 {
                     var ex = new Exception(e.Data);
                     await LogErrorAsync(ex);
                 }
+            })
+            .FileAndForget(
+                nameof(TailwindCSSIntellisense) + "/TailwindSetUpProcess/ErrorDataReceived"
+            );
             })
             .FileAndForget(
                 nameof(TailwindCSSIntellisense) + "/TailwindSetUpProcess/ErrorDataReceived"

--- a/src/Node/TailwindSetUpProcess.cs
+++ b/src/Node/TailwindSetUpProcess.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
@@ -41,6 +42,8 @@ internal sealed class TailwindSetUpProcess
             FileName = "cmd",
             WorkingDirectory = directory,
             Arguments = "/C npm install -D tailwindcss @tailwindcss/cli",
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
         };
 
         try
@@ -120,10 +123,6 @@ internal sealed class TailwindSetUpProcess
                     var ex = new Exception(e.Data);
                     await LogErrorAsync(ex);
                 }
-            })
-            .FileAndForget(
-                nameof(TailwindCSSIntellisense) + "/TailwindSetUpProcess/ErrorDataReceived"
-            );
             })
             .FileAndForget(
                 nameof(TailwindCSSIntellisense) + "/TailwindSetUpProcess/ErrorDataReceived"

--- a/src/source.extension.cs
+++ b/src/source.extension.cs
@@ -12,7 +12,7 @@ namespace TailwindCSSIntellisense
         public const string Name = "Tailwind CSS for Visual Studio";
         public const string Description = @"Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.";
         public const string Language = "en-US";
-        public const string Version = "1.14.0";
+        public const string Version = "1.14.1";
         public const string Author = "Theron Wang";
         public const string Tags = "tailwind, tailwind css, css, html, cshtml, razor, blazor, intellisense, auto-completion";
         public const bool IsPreview = false;

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TailwindCSSIntellisense.b29696d4-76a4-43d1-a203-c8e692368847" Version="1.14.0" Language="en-US" Publisher="Theron Wang" />
+    <Identity Id="TailwindCSSIntellisense.b29696d4-76a4-43d1-a203-c8e692368847" Version="1.14.1" Language="en-US" Publisher="Theron Wang" />
     <DisplayName>Tailwind CSS for Visual Studio</DisplayName>
     <Description xml:space="preserve">Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.</Description>
     <MoreInfo>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio</MoreInfo>


### PR DESCRIPTION
See #152 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of international characters in Tailwind and npm command output.
  * Prevented setup warnings from being reported as errors.
  * Improved npm update error handling.
  * Fixed parsing issues involving locale-specific JSON and `@plugin` configuration blocks.

* **Release**
  * Updated the extension to version 1.14.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->