### PR TITLE
Handle separators in quoted @source strings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
         run: dotnet test tests/TailwindCSSIntellisense.Tests/TailwindCSSIntellisense.Tests.csproj --configuration Release --verbosity normal
 
       - name: Check formatting
+        if: always()
         run: |
           dotnet tool restore
           dotnet csharpier check .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  run-tests:
+  tests:
     runs-on: windows-latest
 
     steps:
@@ -22,19 +22,10 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - run: dotnet test tests/TailwindCSSIntellisense.Tests/TailwindCSSIntellisense.Tests.csproj --configuration Release --verbosity normal
+      - name: Run tests
+        run: dotnet test tests/TailwindCSSIntellisense.Tests/TailwindCSSIntellisense.Tests.csproj --configuration Release --verbosity normal
 
-  check-formatting:
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 10.0.x
-
-      - run: dotnet tool restore
-      - run: dotnet csharpier check .
+      - name: Check formatting
+        run: |
+          dotnet tool restore
+          dotnet csharpier check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.2 (July 21st, 2026)
+
+- Fix a linter false positive resulting from CSS segment-breaking characters (;{}) inside quotes in `@source` directives ([#154](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/154))
+
 ## 1.14.1 (July 19th, 2026)
 
 - Prevent warnings from being recognized as errors in the Tailwind setup process

--- a/README.md
+++ b/README.md
@@ -7,16 +7,32 @@ Bring IntelliSense, linting, class sorting, build tools, and more to Tailwind CS
 
 > **Note**: This extension best supports Tailwind CSS v3+.
 
-- [Download from the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=TheronWang.TailwindCSSIntellisense)
-- [Getting Started Guide](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/Getting-Started.md)
+**[Download from the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=TheronWang.TailwindCSSIntellisense)** · **[Getting Started Guide](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/Getting-Started.md)** · **[Changelog](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/CHANGELOG.md)**
 
-## Changelog
+---
 
-For information on recent updates, see [the changelog](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/CHANGELOG.md).
+## ❤️ Support This Project
 
-## Disclaimer
+This extension is built and maintained solo, in my free time, for the whole VS community.
 
-This is **not** an official Tailwind CSS extension and has **no affiliation** with Tailwind Labs Inc.
+If it's saved you time or made your workflow better, please consider **[sponsoring development on GitHub](https://github.com/sponsors/theron-wang)** — even a small donation helps keep it going and directly funds new features and bug fixes.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Features](#features)
+  - [IntelliSense](#intellisense)
+  - [Linting](#linting)
+  - [Class Sorting](#class-sorting)
+  - [Build Integration](#build-integration)
+  - [NPM Integration](#npm-integration)
+  - [Extension Options](#extension-options)
+- [Troubleshooting](#troubleshooting)
+- [Support & Feedback](#support--feedback)
+- [Disclaimer](#disclaimer)
 
 ## Prerequisites
 
@@ -24,15 +40,15 @@ This extension uses `npm` and `node`, so you should have them installed.
 
 To check whether `npm` is installed, run `npm -v` in the terminal.
 
-If you do not have `npm` installed, follow the [official install guide](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) from the npm docs.
+If you don't have `npm` installed, follow the [official install guide](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) from the npm docs.
 
 ## Setup
 
-The extension activates when:
-- Your solution contains a `tailwind.config.{js,cjs,mjs,ts,cts,mts}` file for Tailwind v3, or
-- You are using Tailwind v4 and importing it in a `.css` file with `@import "tailwindcss"`
+The extension activates automatically when:
+- Your solution contains a `tailwind.config.{js,cjs,mjs,ts,cts,mts}` file (Tailwind v3), or
+- You're using Tailwind v4 and importing it in a `.css` file with `@import "tailwindcss"`
 
-If the config file is not detected, right-click it in Solution Explorer and select **Set as configuration file**.
+If the config file isn't detected automatically, right-click it in Solution Explorer and select **Set as configuration file**.
 
 ## Features
 
@@ -40,7 +56,9 @@ If the config file is not detected, right-click it in Solution Explorer and sele
 
 Get Tailwind class suggestions in Razor, HTML, and CSS files:
 
-![Intellisense Demo](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/IntelliSense-Demo-1.gif)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/IntelliSense-Demo-1.gif" width="700" alt="IntelliSense suggesting Tailwind classes in a Razor file" />
+</p>
 
 ### Linting
 
@@ -48,9 +66,11 @@ Automatically flags:
 - Conflicting classes
 - Invalid `theme()`, `screen()`, or `@tailwind` usage
 
-Note: Visual Studio might still flag some Tailwind features like `@apply` as errors. Extensions cannot override these tags.
+> **Note**: Visual Studio may still flag some Tailwind features like `@apply` as errors — extensions can't override these built-in warnings.
 
-![Linter](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Linter.png)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Linter.png" width="700" alt="Linter flagging conflicting Tailwind classes" />
+</p>
 
 ### Class Sorting
 
@@ -58,25 +78,38 @@ Sort Tailwind classes:
 - Automatically on save or build
 - Manually from the **Tools** menu
 
-![Class Sort Demo 1](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/class-sort-demo.gif)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/class-sort-demo.gif" width="700" alt="Classes being automatically sorted on save" />
+</p>
 
-![Class Sort Demo 2](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Class-Sort-2.png)
+<table align="center">
+<tr>
+<td align="center"><img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Class-Sort-2.png" width="380" alt="Manual class sort from the Tools menu" /></td>
+</tr>
+</table>
 
 ### Build Integration
 
-The extension can build your Tailwind CSS output when you build your project, or manually from the **Build** menu.
+The extension can build your Tailwind CSS output automatically on project build, or manually from the **Build** menu.
+
 - Make sure your input and output CSS files are defined
 - Output and errors appear in the Build output window
 
-![Build Demo 1](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Build-Demo-1.png)
-
-![Build Demo 2](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Build-Demo-2.png)
+<table align="center">
+<tr>
+<td align="center"><img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Build-Demo-1.png" width="380" alt="Build integration output" /></td>
+<td align="center"><img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Build-Demo-2.png" width="380" alt="Build menu with Tailwind build option" /></td>
+</tr>
+</table>
 
 To configure build and configuration files, right-click `.js`, `.ts`, or `.css` files:
 
-![Customizability Build 1](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Customizability-Build-1.png)
-
-![Customizability Build 2](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Customizability-Build-2.png)
+<table align="center">
+<tr>
+<td align="center"><img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Customizability-Build-1.png" width="380" alt="Setting the configuration file via right-click" /></td>
+<td align="center"><img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Customizability-Build-2.png" width="380" alt="Configuring build settings via right-click" /></td>
+</tr>
+</table>
 
 Project-specific settings are saved in a `tailwind.extension.json` file in your project root.
 
@@ -84,40 +117,46 @@ Project-specific settings are saved in a `tailwind.extension.json` file in your 
 
 Start quickly by right-clicking your project and selecting a startup task:
 
-![NPM Shortcut 1](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/NPM-Shortcuts-1.png)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/NPM-Shortcuts-1.png" width="700" alt="NPM startup task shortcuts in the right-click menu" />
+</p>
 
-Using the Tailwind CLI?
-- Set its path under **Tools > Options > Tailwind CSS IntelliSense > Tailwind CLI path**
-- Click **Set up Tailwind CSS (use CLI)**
+**Using the Tailwind CLI?**
+1. Set its path under **Tools > Options > Tailwind CSS IntelliSense > Tailwind CLI path**
+2. Click **Set up Tailwind CSS (use CLI)**
 
-Want to use a custom build script?
-- Define it in your `package.json`
-- Set the script name in the extension options (`npm run your-script-name`)
+**Want to use a custom build script?**
+1. Define it in your `package.json`
+2. Set the script name in the extension options (`npm run your-script-name`)
 
 ### Extension Options
 
-Find global extension settings in:
+Global extension settings live under:
 
 > **Tools > Options > Tailwind CSS IntelliSense**
 
-More details: [Getting Started – Extension Configuration](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/Getting-Started.md#extension-configuration)
+See [Getting Started – Extension Configuration](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/blob/main/Getting-Started.md#extension-configuration) for details.
 
 ## Troubleshooting
 
 ### Build Issues
 
-If your CSS is not updating:
-- Check the **Build output** window for Tailwind errors.
+If your CSS isn't updating, check the **Build output** window for Tailwind errors.
 
-![Build Error Output](https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Troubleshooting-Build.png)<br>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/theron-wang/Tailwind-CSS-for-Visual-Studio/main/art/Troubleshooting-Build.png" width="700" alt="Build output window showing a Tailwind error" />
+</p>
 
 ### Extension Issues
 
-If the extension crashes or behaves unexpectedly:
-- Check the Extensions output window for detailed logs.
+If the extension crashes or behaves unexpectedly, check the **Extensions** output window for detailed logs.
 
-## Support
+## Support & Feedback
 
-To report issues or share feature suggestions, feel free to create an issue [on GitHub](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/new).
+Found a bug or have a feature request? [Open an issue on GitHub](https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio/issues/new).
 
-If this extension has helped you, please consider [leaving a small donation](https://github.com/sponsors/theron-wang) to support development!
+Enjoying the extension? A rating on the [Marketplace listing](https://marketplace.visualstudio.com/items?itemName=TheronWang.TailwindCSSIntellisense) or a **[donation](https://github.com/sponsors/theron-wang)** goes a long way toward keeping it maintained. 🙏
+
+## Disclaimer
+
+This is **not** an official Tailwind CSS extension and has **no affiliation** with Tailwind Labs Inc.

--- a/src/Parsers/CssParser.cs
+++ b/src/Parsers/CssParser.cs
@@ -8,7 +8,7 @@ namespace TailwindCSSIntellisense.Parsers;
 internal static class CssParser
 {
     private static readonly Regex _segmentRegex = new(
-        @"[@;{}](?:""(?:[^""\\]|\\.)*""|[^;{}])*",
+        @"[@;{}](?:""(?:[^""\\]|\\.)*""|'(?:[^'\\]|\\.)*'|[^;{}])*",
         RegexOptions.Compiled,
         TimeSpan.FromSeconds(1)
     );

--- a/src/Parsers/CssParser.cs
+++ b/src/Parsers/CssParser.cs
@@ -8,7 +8,7 @@ namespace TailwindCSSIntellisense.Parsers;
 internal static class CssParser
 {
     private static readonly Regex _segmentRegex = new(
-        @"[@;{}][^;{}]*",
+        @"[@;{}](?:""(?:[^""\\]|\\.)*""|[^;{}])*",
         RegexOptions.Compiled,
         TimeSpan.FromSeconds(1)
     );

--- a/src/source.extension.cs
+++ b/src/source.extension.cs
@@ -12,7 +12,7 @@ namespace TailwindCSSIntellisense
         public const string Name = "Tailwind CSS for Visual Studio";
         public const string Description = @"Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.";
         public const string Language = "en-US";
-        public const string Version = "1.14.1";
+        public const string Version = "1.14.2";
         public const string Author = "Theron Wang";
         public const string Tags = "tailwind, tailwind css, css, html, cshtml, razor, blazor, intellisense, auto-completion";
         public const bool IsPreview = false;

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TailwindCSSIntellisense.b29696d4-76a4-43d1-a203-c8e692368847" Version="1.14.1" Language="en-US" Publisher="Theron Wang" />
+    <Identity Id="TailwindCSSIntellisense.b29696d4-76a4-43d1-a203-c8e692368847" Version="1.14.2" Language="en-US" Publisher="Theron Wang" />
     <DisplayName>Tailwind CSS for Visual Studio</DisplayName>
     <Description xml:space="preserve">Unofficial extension for Tailwind CSS IntelliSense, linting, sorting, and more in Visual Studio 2026 and 2022.</Description>
     <MoreInfo>https://github.com/theron-wang/Tailwind-CSS-for-Visual-Studio</MoreInfo>

--- a/tests/TailwindCSSIntellisense.Tests/Stubs/TestStubs.cs
+++ b/tests/TailwindCSSIntellisense.Tests/Stubs/TestStubs.cs
@@ -83,6 +83,12 @@ namespace Microsoft.VisualStudio.Threading { }
 
 namespace Microsoft.VisualStudio.Text
 {
+    public enum SpanTrackingMode
+    {
+        EdgeExclusive,
+        EdgeInclusive,
+    }
+
     public readonly struct Span(int start, int length)
     {
         public int Start { get; } = start;
@@ -104,6 +110,7 @@ namespace Microsoft.VisualStudio.Text
     public interface ITextSnapshot
     {
         int Length { get; }
+        char this[int index] { get; }
         string GetText(int startIndex, int length);
     }
 
@@ -111,6 +118,7 @@ namespace Microsoft.VisualStudio.Text
     {
         private readonly string _text = text;
         public int Length => _text.Length;
+        public char this[int index] => _text[index];
 
         public string GetText(int startIndex, int length)
         {
@@ -153,19 +161,79 @@ namespace Microsoft.VisualStudio.Text
 
     public interface ITrackingSpan { }
 
-    public readonly struct SnapshotSpan(ITextSnapshot snapshot, int start, int length)
+    public readonly struct SnapshotPoint(ITextSnapshot snapshot, int position)
     {
         public ITextSnapshot Snapshot { get; } = snapshot;
-        public Span Span { get; } = new(start, length);
+        public int Position { get; } = position;
 
-        public int Start => Span.Start;
-        public int End => Span.End;
+        public static SnapshotPoint operator +(SnapshotPoint point, int value)
+        {
+            return new SnapshotPoint(point.Snapshot, point.Position + value);
+        }
+
+        public static SnapshotPoint operator -(SnapshotPoint point, int value)
+        {
+            return new SnapshotPoint(point.Snapshot, point.Position - value);
+        }
+
+        public static implicit operator int(SnapshotPoint point)
+        {
+            return point.Position;
+        }
+
+        public static bool operator <(SnapshotPoint left, int right)
+        {
+            return left.Position < right;
+        }
+
+        public static bool operator >(SnapshotPoint left, int right)
+        {
+            return left.Position > right;
+        }
+
+        public static bool operator <=(SnapshotPoint left, int right)
+        {
+            return left.Position <= right;
+        }
+
+        public static bool operator >=(SnapshotPoint left, int right)
+        {
+            return left.Position >= right;
+        }
+    }
+
+    public sealed class FakeTrackingSpan(int start, int length) : ITrackingSpan
+    {
+        public int Start { get; } = start;
+        public int Length { get; } = length;
+    }
+
+    public readonly struct SnapshotSpan
+    {
+        public SnapshotSpan(ITextSnapshot snapshot, int start, int length)
+        {
+            Snapshot = snapshot;
+            Span = new(start, length);
+        }
+
+        public SnapshotSpan(SnapshotPoint start, int length)
+        {
+            Snapshot = start.Snapshot;
+            Span = new(start.Position, length);
+        }
+
+        public ITextSnapshot Snapshot { get; }
+        public Span Span { get; }
+
+        public SnapshotPoint Start => new(Snapshot, Span.Start);
+        public SnapshotPoint End => new(Snapshot, Span.End);
+        public int Length => Span.Length;
 
         public bool IsEmpty => Span.IsEmpty;
 
         public string GetText()
         {
-            return Snapshot.GetText(Start, Span.Length);
+            return Snapshot.GetText(Span.Start, Span.Length);
         }
 
         public bool Contains(SnapshotSpan other)
@@ -189,6 +257,28 @@ namespace Microsoft.VisualStudio.Text
         public override int GetHashCode()
         {
             return HashCode.Combine(Snapshot, Span.Start, Span.Length);
+        }
+    }
+
+    public static class TextSnapshotExtensions
+    {
+        public static ITrackingSpan CreateTrackingSpan(
+            this ITextSnapshot snapshot,
+            int start,
+            int length,
+            SpanTrackingMode mode
+        )
+        {
+            return new FakeTrackingSpan(start, length);
+        }
+
+        public static ITrackingSpan CreateTrackingSpan(
+            this ITextSnapshot snapshot,
+            SnapshotSpan span,
+            SpanTrackingMode mode
+        )
+        {
+            return new FakeTrackingSpan((int)span.Start, span.Length);
         }
     }
 }
@@ -285,14 +375,31 @@ namespace TailwindCSSIntellisense.Linting
 {
     internal sealed class LinterUtilities
     {
-        public ErrorSeverity GetErrorSeverity(ErrorType type) => ErrorSeverity.None;
+        public static Func<ErrorType, ErrorSeverity> GetErrorSeverityHandler { get; set; } =
+            _ => ErrorSeverity.Warning;
 
-        public IEnumerable<Tuple<string, string>> CheckForClassDuplicates(
+        public static Func<
+            IEnumerable<string>,
+            ProjectCompletionValues,
+            IEnumerable<(
+                string className,
+                string errorMessage,
+                IEnumerable<string> conflictingClasses
+            )>
+        > CheckForClassDuplicatesHandler { get; set; } = (_, _) => [];
+
+        public ErrorSeverity GetErrorSeverity(ErrorType type) => GetErrorSeverityHandler(type);
+
+        public IEnumerable<(
+            string className,
+            string errorMessage,
+            IEnumerable<string> conflictingClasses
+        )> CheckForClassDuplicates(
             IEnumerable<string> classes,
             ProjectCompletionValues projectCompletionValues
         )
         {
-            return [];
+            return CheckForClassDuplicatesHandler(classes, projectCompletionValues);
         }
     }
 }
@@ -404,22 +511,4 @@ namespace TailwindCSSIntellisense.Settings
 namespace TailwindCSSIntellisense.Configuration
 {
     public class CompletionConfiguration { }
-}
-
-namespace TailwindCSSIntellisense.Linting.Validators.Diagnostics
-{
-    public class DiagnosticsAggregator()
-    {
-        internal IEnumerable<Error> GetErrors(
-            SnapshotSpan span,
-            bool isCss,
-            ProjectCompletionValues projectCompletionValues,
-            Func<string, IEnumerable<Match>> findClasses,
-            Func<string, IEnumerable<Match>> splitClasses,
-            Func<SnapshotSpan, bool> shouldNotAddErrors
-        )
-        {
-            return [];
-        }
-    }
 }

--- a/tests/TailwindCSSIntellisense.Tests/TailwindCSSIntellisense.Tests.csproj
+++ b/tests/TailwindCSSIntellisense.Tests/TailwindCSSIntellisense.Tests.csproj
@@ -100,6 +100,10 @@
     <Compile Include="../../src/Linting/Suggestion.cs" Link="Source/Linting/Suggestion.cs" />
     <Compile Include="../../src/Linting/SuggestionFix.cs" Link="Source/Linting/SuggestionFix.cs" />
     <Compile
+      Include="../../src/Linting/Validators/Diagnostics/*.cs"
+      Link="Source/Linting/Validators/Diagnostics/%(Filename)%(Extension)"
+    />
+    <Compile
       Include="../../src/Linting/Validators/CssValidator.cs"
       Link="Source/Linting/CssValidator.cs"
     />

--- a/tests/TailwindCSSIntellisense.Tests/UnitTests/DiagnosticsTests.cs
+++ b/tests/TailwindCSSIntellisense.Tests/UnitTests/DiagnosticsTests.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using Microsoft.VisualStudio.Text;
+using TailwindCSSIntellisense.Completions;
+using TailwindCSSIntellisense.Linting;
+using TailwindCSSIntellisense.Linting.Validators.Diagnostics;
+
+namespace TailwindCSSIntellisense.Tests.UnitTests;
+
+[Collection("Non-Parallel Tests")]
+public class DiagnosticsTests : IDisposable
+{
+    private readonly Func<
+        IEnumerable<string>,
+        ProjectCompletionValues,
+        IEnumerable<(string className, string errorMessage, IEnumerable<string> conflictingClasses)>
+    > _originalConflictHandler = LinterUtilities.CheckForClassDuplicatesHandler;
+
+    private readonly Func<ErrorType, ErrorSeverity> _originalSeverityHandler =
+        LinterUtilities.GetErrorSeverityHandler;
+
+    public void Dispose()
+    {
+        LinterUtilities.CheckForClassDuplicatesHandler = _originalConflictHandler;
+        LinterUtilities.GetErrorSeverityHandler = _originalSeverityHandler;
+    }
+
+    [Fact]
+    public void DeprecatedAtRuleDiagnostics_FlagsVariantAtRule()
+    {
+        var errors = GetErrors(
+            new DeprecatedAtRuleDiagnostics(),
+            "@variant dark (&:is(.dark *));",
+            new ProjectCompletionValues { Version = TailwindVersion.V4 }
+        );
+
+        var error = Assert.Single(errors);
+        Assert.Equal(ErrorType.DeprecatedAtRule, error.ErrorType);
+        Assert.Contains("@custom-variant", error.ErrorMessage);
+        Assert.NotNull(error.Suggestion);
+    }
+
+    [Fact]
+    public void InvalidScreenDiagnostics_FlagsUnknownScreen()
+    {
+        var values = new ProjectCompletionValues { Version = TailwindVersion.V4 };
+        values.Breakpoints["md"] = "768px";
+
+        var errors = GetErrors(new InvalidScreenDiagnostics(), "@screen lg { }", values);
+
+        var error = Assert.Single(errors);
+        Assert.Equal(ErrorType.InvalidScreen, error.ErrorType);
+        Assert.Contains("does not exist", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void InvalidTailwindDirectiveDiagnostics_V3FlagsPreflight()
+    {
+        var errors = GetErrors(
+            new InvalidTailwindDirectiveDiagnostics(),
+            "@tailwind preflight;",
+            new ProjectCompletionValues { Version = TailwindVersion.V3 }
+        );
+
+        var error = Assert.Single(errors);
+        Assert.Equal(ErrorType.InvalidTailwindDirective, error.ErrorType);
+        Assert.Contains("Did you mean 'base'?", error.ErrorMessage);
+        Assert.NotNull(error.Suggestion);
+    }
+
+    [Fact]
+    public void InvalidConfigPathDiagnostics_FlagsUnknownThemePath()
+    {
+        var values = new ProjectCompletionValues { Version = TailwindVersion.V3 };
+        values.SpacingMapper["4"] = "1rem";
+
+        var errors = GetErrors(
+            new InvalidConfigPathDiagnostics(),
+            ".x { margin: theme(spacing.5); }",
+            values
+        );
+
+        var error = Assert.Single(errors);
+        Assert.Equal(ErrorType.InvalidConfigPath, error.ErrorType);
+        Assert.Contains("does not exist in your theme config", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void InvalidSourceDiagnostics_FlagsWindowsStylePath()
+    {
+        var errors = GetErrors(
+            new InvalidSourceDiagnostics(),
+            "@import \"tailwindcss\" source(\"C:\\\\styles\");",
+            new ProjectCompletionValues { Version = TailwindVersion.V4 }
+        );
+
+        var error = Assert.Single(errors);
+        Assert.Equal(ErrorType.InvalidSource, error.ErrorType);
+        Assert.Contains("Windows-style path", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void UsedBlocklistClassDiagnostics_FlagsBlockedClass()
+    {
+        var values = new ProjectCompletionValues { Version = TailwindVersion.V3 };
+        values.Blocklist.Add("foo");
+
+        var errors = GetErrors(
+            new UsedBlocklistClassDiagnostics(),
+            "<div class=\"foo bar foo\"></div>",
+            values
+        );
+
+        Assert.Equal(2, errors.Count);
+        Assert.All(errors, error => Assert.Equal(ErrorType.UsedBlocklistClass, error.ErrorType));
+    }
+
+    [Fact]
+    public void CssConflictDiagnostics_FlagsConflictingClasses()
+    {
+        LinterUtilities.CheckForClassDuplicatesHandler = (_, _) =>
+            [
+                (
+                    "text-red-500",
+                    "'text-red-500' applies the same CSS properties as 'bg-red-500'.",
+                    new[] { "bg-red-500" }
+                ),
+            ];
+
+        var errors = GetErrors(
+            new CssConflictDiagnostics(),
+            "<div class=\"text-red-500 bg-red-500\"></div>",
+            new ProjectCompletionValues { Version = TailwindVersion.V3 }
+        );
+
+        var error = Assert.Single(errors);
+        Assert.Equal(ErrorType.CssConflict, error.ErrorType);
+        Assert.Contains("same CSS properties", error.ErrorMessage);
+    }
+
+    private static List<Error> GetErrors(
+        DiagnosticsChecker checker,
+        string text,
+        ProjectCompletionValues values
+    )
+    {
+        var span = new SnapshotSpan(new StringTextSnapshot(text), 0, text.Length);
+        Inject(checker, "_linterUtilities", new LinterUtilities());
+
+        if (checker is InvalidConfigPathDiagnostics)
+        {
+            Inject(checker, "_projectConfigurationManager", new ProjectConfigurationManager());
+        }
+
+        return checker
+            .GetErrors(
+                span,
+                values,
+                ClassRegexHelper.GetClassesNormal,
+                ClassRegexHelper.SplitNonRazorClasses,
+                _ => false
+            )
+            .ToList();
+    }
+
+    private static void Inject(object instance, string fieldName, object value)
+    {
+        var field = instance
+            .GetType()
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+
+        if (field is null)
+        {
+            field = typeof(DiagnosticsChecker).GetField(
+                fieldName,
+                BindingFlags.Instance | BindingFlags.NonPublic
+            );
+        }
+
+        Assert.NotNull(field);
+        field!.SetValue(instance, value);
+    }
+}

--- a/tests/TailwindCSSIntellisense.Tests/UnitTests/DiagnosticsTests.cs
+++ b/tests/TailwindCSSIntellisense.Tests/UnitTests/DiagnosticsTests.cs
@@ -99,6 +99,40 @@ public class DiagnosticsTests : IDisposable
     }
 
     [Fact]
+    public void InvalidSourceDiagnostics_HandlesValidInlineSource()
+    {
+        var errors = GetErrors(
+            new InvalidSourceDiagnostics(),
+            "@source inline(\"{p}-{px}\");",
+            new ProjectCompletionValues { Version = TailwindVersion.V4 }
+        );
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void InvalidSourceDiagnostics_FlagsInvalidInlineSource()
+    {
+        var errors = GetErrors(
+            new InvalidSourceDiagnostics(),
+            """
+@source none;
+@source inline(invalid;
+""",
+            new ProjectCompletionValues { Version = TailwindVersion.V4 }
+        );
+
+        Assert.Equal(2, errors.Count);
+        Assert.All(errors, error => Assert.Equal(ErrorType.InvalidSource, error.ErrorType));
+        Assert.Contains(
+            errors,
+            error =>
+                error.ErrorMessage.Contains("inline") && error.ErrorMessage.Contains("is invalid")
+        );
+        Assert.Contains(errors, error => error.ErrorMessage.Contains("source(none)"));
+    }
+
+    [Fact]
     public void UsedBlocklistClassDiagnostics_FlagsBlockedClass()
     {
         var values = new ProjectCompletionValues { Version = TailwindVersion.V3 };

--- a/tests/TailwindCSSIntellisense.Tests/UnitTests/DiagnosticsTests.cs
+++ b/tests/TailwindCSSIntellisense.Tests/UnitTests/DiagnosticsTests.cs
@@ -103,7 +103,7 @@ public class DiagnosticsTests : IDisposable
     {
         var errors = GetErrors(
             new InvalidSourceDiagnostics(),
-            "@source inline(\"{p}-{px}\");",
+            "@source inline(\"{p}-{px}\"); @source inline('{p}-{px}');",
             new ProjectCompletionValues { Version = TailwindVersion.V4 }
         );
 


### PR DESCRIPTION
See #154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS parsing for quoted `@source` directives, correctly handling escaped characters and segment-breaking symbols inside strings.
  * Fixed a linter false positive that could incorrectly flag valid inline source definitions.

* **Documentation**
  * Updated the README with clearer setup, navigation, and troubleshooting information, plus revised support and feedback guidance.
  * Added changelog details for version 1.14.2.

* **Release**
  * Released extension version **1.14.2** (updated VSIX version and manifest).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->